### PR TITLE
Using previous knitr version

### DIFF
--- a/tic.R
+++ b/tic.R
@@ -1,11 +1,10 @@
 get_stage("install") %>%
   add_step(step_install_cran("dataseries")) %>%
-  add_step(step_install_cran("timetk")) %>%
-  add_step(step_install_cran("flexdashboard")) %>%
   add_step(step_install_cran("dygraphs")) %>%
+  add_step(step_install_cran("flexdashboard")) %>%
+  add_step(step_install_cran("htmlwidgets"))
+  add_step(step_install_cran("timetk")) %>%
   add_step(step_install_cran("tsbox")) %>%
-  add_step(step_install_cran("htmlwidgets")) %>%
-  add_step(step_install_cran("timetk"))
 
 get_stage("before_deploy") %>%
   add_step(step_setup_ssh()) %>%

--- a/tic.R
+++ b/tic.R
@@ -2,9 +2,10 @@ get_stage("install") %>%
   add_step(step_install_cran("dataseries")) %>%
   add_step(step_install_cran("dygraphs")) %>%
   add_step(step_install_cran("flexdashboard")) %>%
-  add_step(step_install_cran("htmlwidgets"))
+  add_step(step_install_cran("htmlwidgets")) %>%
   add_step(step_install_cran("timetk")) %>%
   add_step(step_install_cran("tsbox")) %>%
+  add_step(step_install_github("yihui/knitr@v1.29"))  #TODO: use current version when fixed
 
 get_stage("before_deploy") %>%
   add_step(step_setup_ssh()) %>%


### PR DESCRIPTION
1. Removed a duplicated package installation from tic setup steps.
2. Added install instructions for a previous version of knitr.